### PR TITLE
Remove '-Ywarn-numeric-widen' due to issues in 2.10.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,6 @@ lazy val compilerOptions = Seq(
   "-Xlint",
   "-Yno-adapted-args",
   "-Ywarn-dead-code",
-  "-Ywarn-numeric-widen",
   "-Ywarn-value-discard",
   "-Xfuture"
 )


### PR DESCRIPTION
Triggers what looks like a false-negative in 2.10.5, not triggered in 2.11.7.