### PR TITLE
Add ops with more precise types when available

### DIFF
--- a/src/test/scala/pathy/path.scala
+++ b/src/test/scala/pathy/path.scala
@@ -17,6 +17,7 @@
 package pathy
 
 import org.specs2.mutable._
+import scalaz.syntax.foldable._
 
 class PathSpecs extends Specification {
   import Path._
@@ -82,6 +83,13 @@ class PathSpecs extends Specification {
 
   "depth - negative" in {
     depth(parentDir1(parentDir1(parentDir1(currentDir)))) must_== -3
+  }
+
+  "flatten - returns NEL of result of folding each layer of path" in {
+    flatten(
+      "r", "c", "p", identity, identity,
+      currentDir </> dir("foo") </> dir("bar") </> file("flat.md")
+    ).toList must_== List("c", "foo", "bar", "flat.md")
   }
 
   "parseRelFile - image.png" in {


### PR DESCRIPTION
* `fileParent` returns a `Path[_,Dir,_]` as a `Path[_,File,_]` must have a parent dir
* `flatten` should return a `OneAnd[IList, X]` as every `Path` has at least one component
* `refineType` to return either a `Path[_,Dir_]` or `Path[_,File,_]`