### PR TITLE
Make developer an sbt SettingKey

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -87,15 +87,13 @@ lazy val publishSettings = Seq(
       "scm:git@github.com:slamdata/scala-pathy.git"
     )
   ),
-  pomExtra := (
-    <developers>
-      <developer>
-        <id>slamdata</id>
-        <name>SlamData Inc.</name>
-        <url>http://slamdata.com</url>
-        <email>contact@slamdata.com</email>
-      </developer>
-    </developers>
+  developers := List(
+    Developer(
+      id = "slamdata",
+      name = "SlamData Inc.",
+      email = "contact@slamdata.com",
+      url = new URL("http://slamdata.com")
+    )
   )
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9


### PR DESCRIPTION
Last time we were still using sbt 0.13.8 which has a bug generating a proper pom for the developer key. But this time, this change includes an upgrade to sbt 0.13.9 in order to fix this issue.