### PR TITLE
Improve path generators

### DIFF
--- a/scalacheck/src/main/scala/pathy/scalacheck/RandomSeg.scala
+++ b/scalacheck/src/main/scala/pathy/scalacheck/RandomSeg.scala
@@ -28,9 +28,10 @@ private[scalacheck] object RandomSeg {
   implicit val randomSegArbitrary: Arbitrary[RandomSeg] =
     Arbitrary {
       Gen.nonEmptyListOf(Gen.frequency(
-        100 -> Arbitrary.arbitrary[Char],
+        100 -> Gen.alphaNumChar,
          10 -> Gen.const('.'),
-         10 -> Gen.const('/')
+         10 -> Gen.const('/'),
+          5 -> Arbitrary.arbitrary[Char]
       )) map (cs => RandomSeg(cs.mkString))
     }
 


### PR DESCRIPTION
The incoming `size` parameter is now respected, and the available size is distributed among the generated path segments. Crucially, that means `/` and `.` can now be generated (and *alway* are, when size = 0), along with simple paths like `/a` and also much deeper paths, all under the control of the caller.

Biased the segment generator to produce mostly simple, alpha-numeric path segments, with arbitrary Unicode characters appearing less often. This just makes it easier to read the resulting paths most of the time, without sacrificing coverage.