### PR TITLE
parse terminal `.` and `..` as simple file names

### DIFF
--- a/core/src/main/scala/pathy/Path.scala
+++ b/core/src/main/scala/pathy/Path.scala
@@ -297,13 +297,12 @@ object Path {
 
       def folder[B,T,S](base: Path[B,T,S], t: (String, Int)): Path[B,T,S] = t match {
         case ("", _)    => base
+        case (seg, idx) if isFile && idx == last =>
+          FileIn(base, FileName(unescape(seg)))
         case (".", _)   => base
         case ("..", _)  => ParentIn(base)
         case (seg, idx) =>
-          if (isFile && idx == last)
-            FileIn(base, FileName(unescape(seg)))
-          else
-            DirIn(base, DirName(unescape(seg)))
+          DirIn(base, DirName(unescape(seg)))
       }
 
       if (str == "")

--- a/tests/src/test/scala/pathy/path.scala
+++ b/tests/src/test/scala/pathy/path.scala
@@ -124,6 +124,14 @@ class PathSpecs extends Specification with ScalaCheck {
     parseRelFile("foo/") must beNone
   }
 
+  "parseRelFile - ." in {
+    parseRelFile(".") must beSome(file("."))
+  }
+
+  "parseRelFile - foo/.." in {
+    parseRelFile("foo/..") must beSome(dir("foo") </> file(".."))
+  }
+
   "parseAbsFile - /image.png" in {
     parseAbsFile("/image.png") must beSome(rootDir </> file("image.png"))
   }
@@ -138,6 +146,14 @@ class PathSpecs extends Specification with ScalaCheck {
 
   "parseAbsFile - foo/image.png" in {
     parseAbsFile("foo/image.png") must beNone
+  }
+
+  "parseAbsFile - /." in {
+    parseAbsFile("/.") must beSome(rootDir </> file("."))
+  }
+
+  "parseRelFile - /foo/.." in {
+    parseAbsFile("/foo/..") must beSome(rootDir </> dir("foo") </> file(".."))
   }
 
   "parseRelDir - empty string" in {


### PR DESCRIPTION
Fixes #23.

This closes a hole where the parser would produce paths whose values did not match their types. For example, `parseRelFile("foo/.")` would return `Some(currentDir </> dir("foo"))`, obviously a directory path, but in the type `Option[Path[Rel, File, Unsandboxed]]`.

Note: an equally valid fix would be to reject these paths and just return `None`. This would still be safe because `printPath` will escape these paths (e.g. `currentDir </> dir("foo") </> file(".")` is printed as `foo/$dot$`), and never emits a terminal `.` or `..`.