### PR TITLE
Add 'argonaut' project and JSON codecs using the POSIX codec

### DIFF
--- a/CHANGELOG/bugfix.md
+++ b/CHANGELOG/bugfix.md
@@ -1,0 +1,1 @@
+- Add 'argonaut' project and JSON codecs using the POSIX codec

--- a/argonaut/src/main/scala/pathy/argonaut/PosixCodecJson.scala
+++ b/argonaut/src/main/scala/pathy/argonaut/PosixCodecJson.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014 - 2015 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pathy.argonaut
+
+import pathy.Path, Path._
+
+import argonaut._, Argonaut._
+
+object PosixCodecJson {
+  import posixCodec._
+
+  implicit val relFileDecodeJson: DecodeJson[RelFile[Unsandboxed]] =
+    decodeRelPath("File", parseRelFile)
+
+  implicit val relDirDecodeJson: DecodeJson[RelDir[Unsandboxed]] =
+    decodeRelPath("Dir", parseRelDir)
+
+  implicit val absFileDecodeJson: DecodeJson[AbsFile[Sandboxed]] =
+    decodeAbsPath("File", parseAbsFile)
+
+  implicit val absDirDecodeJson: DecodeJson[AbsDir[Sandboxed]] =
+    decodeAbsPath("Dir", parseAbsDir)
+
+  implicit def pathEncodeJson[B, T, S]: EncodeJson[Path[B, T, S]] =
+    EncodeJson.of[String].contramap(unsafePrintPath)
+
+  ////
+
+  private def decodeRelPath[T](
+    typeName: String,
+    parse: String => Option[Path[Rel, T, Unsandboxed]]
+  ): DecodeJson[Path[Rel, T, Unsandboxed]] =
+    DecodeJson.of[String] flatMap { str =>
+      DecodeJson { cur => parse(str) match {
+        case Some(path) => DecodeResult.ok(path)
+        case None       => DecodeResult.fail(s"Rel${typeName}[Unsandboxed]", cur.history)
+      }}
+    }
+
+  private def decodeAbsPath[T](
+    typeName: String,
+    parse: String => Option[Path[Abs, T, Unsandboxed]]
+  ): DecodeJson[Path[Abs, T, Sandboxed]] =
+    DecodeJson.of[String] flatMap { str =>
+      DecodeJson { cur => parse(str).flatMap(sandbox(rootDir, _)) match {
+        case Some(path) => DecodeResult.ok(rootDir </> path)
+        case None       => DecodeResult.fail(s"Abs${typeName}[Sandboxed]", cur.history)
+      }}
+    }
+}

--- a/argonaut/src/test/scala/pathy/argonaut/PosixCodecJsonSpec.scala
+++ b/argonaut/src/test/scala/pathy/argonaut/PosixCodecJsonSpec.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2014 - 2015 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pathy.argonaut
+
+import pathy.Path, Path._
+import pathy.scalacheck.PathyArbitrary._
+
+import argonaut._, Argonaut._
+import org.specs2.mutable
+import org.specs2.ScalaCheck
+
+final class PosixCodecJsonSpec extends mutable.Specification with ScalaCheck {
+  import PosixCodecJson._
+
+  "RelFile Codec" ! prop { rf: RelFile[Sandboxed] =>
+    CodecJson.codecLaw(CodecJson.derived[RelFile[Unsandboxed]])(unsandbox(rf))
+  }
+
+  "RelDir Codec" ! prop { rd: RelDir[Sandboxed] =>
+    CodecJson.codecLaw(CodecJson.derived[RelDir[Unsandboxed]])(unsandbox(rd))
+  }
+
+  "AbsFile Codec" ! prop { af: AbsFile[Sandboxed] =>
+    CodecJson.codecLaw(CodecJson.derived[AbsFile[Sandboxed]])(af)
+  }
+
+  "AbsDir Codec" ! prop { ad: AbsDir[Sandboxed] =>
+    CodecJson.codecLaw(CodecJson.derived[AbsDir[Sandboxed]])(ad)
+  }
+
+  "RelFile encode" ! prop { rf: RelFile[Sandboxed] =>
+    rf.asJson ==== jString(posixCodec.printPath(rf))
+  }
+
+  "RelDir encode" ! prop { rd: RelDir[Sandboxed] =>
+    rd.asJson ==== jString(posixCodec.printPath(rd))
+  }
+
+  "AbsFile encode" ! prop { af: AbsFile[Sandboxed] =>
+    af.asJson ==== jString(posixCodec.printPath(af))
+  }
+
+  "AbsFile encode" ! prop { ad: AbsDir[Sandboxed] =>
+    ad.asJson ==== jString(posixCodec.printPath(ad))
+  }
+
+  "Decode failure" ! prop { s: String =>
+    (!s.isEmpty && !s.contains('\\') && !s.contains('"')) ==> {
+
+    val jstr = s""""$s""""
+
+    def decodeAs[X: DecodeJson]: Either[String, X] =
+      jstr.decodeWithEither[Either[String, X], X](
+        Right(_),
+        e => Left(e.fold(s => s, _._1)))
+
+    (decodeAs[RelDir[Unsandboxed]] must beLeft("RelDir[Unsandboxed]")) and
+    (decodeAs[AbsDir[Sandboxed]] must beLeft("AbsDir[Sandboxed]"))
+  }}
+}

--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ lazy val noPublishSettings = Seq(
 )
 
 lazy val root = (project in file("."))
-  .aggregate(core, scalacheck, tests)
+  .aggregate(core, argonaut, scalacheck, tests)
   .settings(allSettings)
   .settings(noPublishSettings)
   .settings(Seq(
@@ -97,6 +97,19 @@ lazy val core = (project in file("core"))
     initialCommands in console := "import pathy._, Path._",
     libraryDependencies ++= Seq(
       "org.scalaz" %% "scalaz-core" % scalazVersion
+    )
+  ))
+
+lazy val argonaut = (project in file("argonaut"))
+  .dependsOn(core, scalacheck)
+  .enablePlugins(AutomateHeaderPlugin)
+  .settings(allSettings)
+  .settings(Seq(
+    name := "pathy-argonaut",
+    libraryDependencies ++= Seq(
+      "io.argonaut" %% "argonaut" % "6.2-M1",
+      "org.specs2" %% "specs2-core" % specs2Version % "test",
+      "org.specs2" %% "specs2-scalacheck" % specs2Version % "test"
     )
   ))
 


### PR DESCRIPTION
Codecs reflect what has become our common practice of treating absolute paths as sandboxed and relative ones and unsandboxed.