### PR TITLE
good coverage for ASCII in generated paths

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- improve coverage of ASCII characters in Path generators

--- a/scalacheck/src/main/scala/pathy/scalacheck/RandomSeg.scala
+++ b/scalacheck/src/main/scala/pathy/scalacheck/RandomSeg.scala
@@ -22,19 +22,24 @@ import org.scalacheck.Gen
 
 import scalaz.Show
 
+/** Newtype for path segment strings with a generator that produces mostly 
+  * alphanumeric, then any printable ASCII char, with slightly more `.` and `/` 
+  * characters (because they tend to be problematic for encoders), and finally 
+  * an occasional char from anywhere in Unicode. */
 private[scalacheck] final case class RandomSeg(str: String) extends AnyVal
 
 private[scalacheck] object RandomSeg {
-  implicit val randomSegArbitrary: Arbitrary[RandomSeg] =
+  implicit val arbitrary: Arbitrary[RandomSeg] =
     Arbitrary {
       Gen.nonEmptyListOf(Gen.frequency(
-        100 -> Gen.alphaNumChar,
-         10 -> Gen.const('.'),
-         10 -> Gen.const('/'),
-          5 -> Arbitrary.arbitrary[Char]
+        50 -> Gen.alphaChar,
+        25 -> Gen.choose(MinPrintableASCII, MaxPrintableASCII),
+        10 -> Gen.const('.'),
+        10 -> Gen.const('/'),
+         5 -> Arbitrary.arbitrary[Char]
       )) map (cs => RandomSeg(cs.mkString))
     }
 
-  implicit val randomSegShow: Show[RandomSeg] =
+  implicit val show: Show[RandomSeg] =
     Show.shows(_.str)
 }

--- a/scalacheck/src/main/scala/pathy/scalacheck/package.scala
+++ b/scalacheck/src/main/scala/pathy/scalacheck/package.scala
@@ -57,4 +57,7 @@ package object scalacheck {
           t <- Gen.resize(r, sizeDistributedListOfNonEmpty(g))
         } yield (h :: t)
     }
+    
+  val MinPrintableASCII = '\u0020'
+  val MaxPrintableASCII = '\u007e'
 }


### PR DESCRIPTION
This is the improvement that made it easy to spot the bug in quasar-analytics/quasar#1450, turing some flakyTests into dependable failures.

The fix there, quasar-analytics/quasar#1463, does not require this change, but it would good to get this released anyway to prevent similar problems from cropping up in the future.