### PR TITLE
Add scalaz.Order instances

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,9 +85,10 @@ lazy val tests = (project in file("tests"))
   .settings(Seq(
     name := "pathy-tests",
     libraryDependencies ++= Seq(
-      CommonDependencies.scalaz.core            % Test,
-      CommonDependencies.specs2.core            % Test,
-      CommonDependencies.specs2.scalacheck      % Test,
-      CommonDependencies.scalacheck.scalacheck  % Test
+      CommonDependencies.scalaz.core                                                 % Test,
+      CommonDependencies.specs2.core                                                 % Test,
+      CommonDependencies.specs2.scalacheck                                           % Test,
+      CommonDependencies.scalacheck.scalacheck                                       % Test,
+      "org.scalaz" %% "scalaz-scalacheck-binding" % CommonDependencies.scalazVersion % Test
     )
   ))

--- a/core/src/main/scala/pathy/Path.scala
+++ b/core/src/main/scala/pathy/Path.scala
@@ -366,7 +366,7 @@ object Path {
     private val $dotdot$ = "$dotdot$"
   }
 
-  implicit def PathShow[B,T,S]: Show[Path[B,T,S]] = new Show[Path[B,T,S]] {
+  implicit def pathShow[B,T,S]: Show[Path[B,T,S]] = new Show[Path[B,T,S]] {
     override def show(v: Path[B,T,S]): Cord = v match {
       case Current                => "currentDir"
       case Root                   => "rootDir"
@@ -376,5 +376,13 @@ object Path {
     }
   }
 
-  implicit def PathEqual[B,T,S]: Equal[Path[B,T,S]] = Equal.equalA
+  implicit def pathOrder[B,T,S]: Order[Path[B,T,S]] =
+    Order.orderBy(p =>
+      flatten[(Option[Int], Option[String \/ String])](
+        root       =      (some(0),          none),
+        parentDir  =      (some(1),          none),
+        currentDir =      (some(2),          none),
+        dirName    = s => (none   , some( s.left)),
+        fileName   = s => (none   , some(s.right)),
+        path       = p))
 }

--- a/core/src/main/scala/pathy/Path.scala
+++ b/core/src/main/scala/pathy/Path.scala
@@ -53,7 +53,23 @@ object Path {
       FileName(dropExtension.value + "." + f(extension))
   }
 
+  object FileName {
+    implicit val order: Order[FileName] =
+      Order.orderBy(_.value)
+
+    implicit val show: Show[FileName] =
+      Show.shows(_.value)
+  }
+
   final case class DirName(value: String) extends AnyVal
+
+  object DirName {
+    implicit val order: Order[DirName] =
+      Order.orderBy(_.value)
+
+    implicit val show: Show[DirName] =
+      Show.shows(_.value)
+  }
 
   // Note: this ADT allows invalid paths, but the exposed functions
   // of the package do not.

--- a/scalacheck/src/main/scala/pathy/scalacheck/PathNameOf.scala
+++ b/scalacheck/src/main/scala/pathy/scalacheck/PathNameOf.scala
@@ -52,10 +52,10 @@ object PathNameOf {
   ////
 
   private[scalacheck] def genFileName[A: Arbitrary: Show]: Gen[FileName] =
-    genSegment[A].map(FileName)
+    genSegment[A].map(FileName(_))
 
   private[scalacheck] def genDirName[A: Arbitrary: Show]: Gen[DirName] =
-    genSegment[A].map(DirName)
+    genSegment[A].map(DirName(_))
 
   private def genSegment[A: Arbitrary: Show]: Gen[String] =
     Arbitrary.arbitrary[A] map (_.shows)

--- a/tests/src/test/scala/pathy/PathSpecs.scala
+++ b/tests/src/test/scala/pathy/PathSpecs.scala
@@ -17,14 +17,37 @@
 package pathy
 
 import slamdata.Predef._
+import pathy.scalacheck._
 
 import scala.Predef.identity
 
+import org.scalacheck._, Arbitrary.arbitrary
+import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
+import scalaz.scalacheck.ScalazProperties._
 import scalaz.syntax.foldable._
 
-class PathSpecs extends Specification {
-  import Path._
+class PathSpecs extends Specification with ScalaCheck {
+  import Path._, PathyArbitrary._
+
+  "FileName" in {
+    "order laws" >> order.laws[FileName]
+  }
+
+  "DirName" in {
+    "order laws" >> order.laws[DirName]
+  }
+
+  "Path" in {
+    implicit val arbitraryPath: Arbitrary[Path[Any,Any,Sandboxed]] =
+      Arbitrary(Gen.oneOf(
+        arbitrary[AbsFile[Sandboxed]],
+        arbitrary[RelFile[Sandboxed]],
+        arbitrary[AbsDir[Sandboxed]],
+        arbitrary[RelDir[Sandboxed]]))
+
+    "order laws" >> order.laws[Path[Any,Any,Sandboxed]]
+  }
 
   "</> - ./../foo/" in {
     posixCodec.unsafePrintPath(parentDir1(currentDir) </> unsandbox(dir("foo"))) must_== "./../foo/"


### PR DESCRIPTION
Adds `Order` instances for `DirName`, `FileName`, and `Path` as well as `Show` instances for `DirName` and  `FileName`.